### PR TITLE
Add table as return type in action mutation

### DIFF
--- a/apps/core/mutations.py
+++ b/apps/core/mutations.py
@@ -166,7 +166,7 @@ class PerformTableAction(graphene.Mutation):
 
     errors = graphene.List(graphene.NonNull(CustomErrorType))
     ok = graphene.Boolean()
-    result = graphene.Int()
+    result = graphene.Field(TableType)
 
     @staticmethod
     @lift_mutate_with_instance(Table)
@@ -196,7 +196,7 @@ class PerformTableAction(graphene.Mutation):
         transaction.on_commit(
             lambda: calculate_column_stats_for_action.delay(action_obj.id)
         )
-        return PerformTableAction(result=action_obj.id, errors=None, ok=True)
+        return PerformTableAction(result=table, errors=None, ok=True)
 
 
 class TableJoinMutation(graphene.Mutation):

--- a/apps/core/tests/test_mutations.py
+++ b/apps/core/tests/test_mutations.py
@@ -272,6 +272,10 @@ class TestTableActions(GraphQLTestCase, BaseTestWithDataFrameAndExcel, TestCase)
                 tableAction(id: $tableId action: $action) {
                     ok
                     errors
+                    result {
+                        id
+                        name
+                    }
                 }
             }
         """
@@ -300,6 +304,7 @@ class TestTableActions(GraphQLTestCase, BaseTestWithDataFrameAndExcel, TestCase)
         new_action = Action.objects.filter(order=1, table=self.table).last()
         assert new_action is not None
         col_stats_delay_func.assert_called_with(new_action.pk)
+        self.assertEqual(content["result"]["id"], str(self.variables["tableId"]))
 
 
 @override_settings(MEDIA_ROOT=TEST_MEDIA_DIR)


### PR DESCRIPTION
Resolves #66 

## Changes
- Change result type to tableType

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
